### PR TITLE
[#8] NFC 태그 기능 작업

### DIFF
--- a/Pikacho/Pikacho/Model/PCColorList.swift
+++ b/Pikacho/Pikacho/Model/PCColorList.swift
@@ -57,8 +57,4 @@ enum PCColorList: Int, CaseIterable, Hashable, Codable {
             return Color(hex: 0xFCD1BE)
         }
     }
-
-
-
-   
 }

--- a/Pikacho/Pikacho/PikachoApp.swift
+++ b/Pikacho/Pikacho/PikachoApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct PikachoApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            NFCTagScanView()
         }
     }
 }

--- a/Pikacho/Pikacho/Util/NFCFeature.swift
+++ b/Pikacho/Pikacho/Util/NFCFeature.swift
@@ -1,7 +1,41 @@
 //
-//  NFCManager.swift
+//  NFCFeature.swift
 //  Pikacho
 //
 //  Created by Hajin on 6/18/24.
 //
 
+import Foundation
+import CoreNFC
+
+class NFCFeature: NSObject, ObservableObject, NFCNDEFReaderSessionDelegate {
+    @Published var messages: [NFCNDEFMessage] = []
+    var session: NFCNDEFReaderSession?
+
+    func beginScanning() {
+        guard NFCNDEFReaderSession.readingAvailable else {
+            print("This device doesn't support NFC scanning.")
+            return
+        }
+
+        session = NFCNDEFReaderSession(delegate: self, queue: nil, invalidateAfterFirstRead: false)
+        session?.alertMessage = "Hold your iphone near the item to learn more about it."
+        session?.begin()
+    }
+
+    func readerSession(_ session: NFCNDEFReaderSession, didDetectNDEFs messages: [NFCNDEFMessage]) {
+        DispatchQueue.main.async {
+            self.messages.append(contentsOf: messages)
+        }
+    }
+
+    func readerSession(_ session: NFCNDEFReaderSession, didInvalidateWithError error: Error) {
+        if let readerError = error as? NFCReaderError {
+            if readerError.code != .readerSessionInvalidationErrorFirstNDEFTagRead && readerError.code != .readerSessionInvalidationErrorUserCanceled {
+
+                print("NFC Session invalidated: \(error.localizedDescription)")
+            }
+        }
+        self.session = nil
+    }
+}

--- a/Pikacho/Pikacho/View/CheckView.swift
+++ b/Pikacho/Pikacho/View/CheckView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import SwiftData
 
+
 struct CheckView: View {
     
     @State private var showYeView: Bool = false
@@ -29,11 +30,11 @@ struct CheckView: View {
                     Text("Number of People: \(booking.numberOfPeople ?? 0)")
                     Text("Password: \(booking.password)")
                     //Text("Color: \(booking.colorOfRow.rawValue)")
-                    Text("Color: \(booking.colorOfRow.tabkeBackgroundColor.description)")
+                    Text("Color: \(booking.colorOfRow.tableBackgroundColor.description)")
 
                 }
                 .padding()
-                .background(booking.colorOfRow.tabkeBackgroundColor)
+                .background(booking.colorOfRow.tableBackgroundColor)
                 .cornerRadius(8)
             }
         }

--- a/Pikacho/Pikacho/View/ContentView.swift
+++ b/Pikacho/Pikacho/View/ContentView.swift
@@ -107,10 +107,10 @@ struct ContentView: View {
     private func TableViewForReservation() -> some View {
         VStack(alignment:.trailing, spacing: 4){
             Rectangle()
-                .fill(Color.gray)
+                .fill(.gray)
                 .frame(width: 309, height: 1)
             Button{}label:{
-                RoundedRectangle(cornerRadius: 5).frame(width:255, height: 36).foregroundColor(.gray)
+                RoundedRectangle(cornerRadius: 5).frame(width:255, height: 36).foregroundColor(PCColorList.default.tableBackgroundColor)
             }.padding(.horizontal, 8)
 
         }

--- a/Pikacho/Pikacho/View/NFCTagScanView.swift
+++ b/Pikacho/Pikacho/View/NFCTagScanView.swift
@@ -5,4 +5,102 @@
 //  Created by Hajin on 6/18/24.
 //
 
+import SwiftUI
+import CoreNFC
 
+struct NFCTagScanView: View {
+    @State private var showingAlert = false
+    @State private var alertMessage = ""
+    @State private var session: NFCNDEFReaderSession?
+    @State private var haveToNavigate = false
+    var body: some View {
+        VStack{
+            VStack{
+                HStack{
+                    Text("Meet-ing").font(.PikachoHeadiline)
+                    Spacer()
+                }.padding(EdgeInsets(top: 20, leading: 0, bottom: 10, trailing: 0))
+                HStack{
+                    Text("미팅룸 예약을 위해").font(.PikachoButton)
+                    Spacer()
+                }
+                HStack{
+                    Text("NFC 태그에 아이폰을 가까이 가져가세요.").font(.PikachoButton)
+                    Spacer()
+                }
+            }.frame(width: 361, height: 97)
+                .padding(0)
+
+            Spacer()
+
+            Image(systemName: "airtag.radiowaves.forward")
+                .resizable()
+                .frame(width: 297, height: 189)
+                .foregroundColor(Color(hex: 0x523BDB))
+
+            Spacer()
+
+            Button{
+                beginScanning()
+            }label: {
+                ZStack{
+                    RoundedRectangle(cornerRadius: 10).fill(Color(hex: 0x523BDB)).frame(width: 361, height: 51)
+                    Text("스캔하기").foregroundColor(.white).font(.PikachoButton)
+                }
+            }
+
+            NavigationLink(destination: ContentView(), isActive: $haveToNavigate) {
+                EmptyView()
+            }
+        }.alert(isPresented: $showingAlert) {
+            Alert(title: Text("Error"), message: Text(alertMessage), dismissButton: .default(Text("OK")))
+        }
+
+    }
+    private func beginScanning() {
+        guard NFCNDEFReaderSession.readingAvailable else {
+            alertMessage = "This device doesn't support tag scanning."
+            showingAlert = true
+            return
+        }
+
+        session = NFCNDEFReaderSession(delegate: NFCDelegate(showingAlert: $showingAlert, alertMessage: $alertMessage, haveToNavigate: $haveToNavigate), queue: nil, invalidateAfterFirstRead: false)
+        session?.alertMessage = "Hold your iphone near the item to learn more about it."
+        session?.begin()
+    }
+}
+
+class NFCDelegate: NSObject, NFCNDEFReaderSessionDelegate {
+    @Binding var haveToNavigate: Bool
+    @Binding var showingAlert: Bool
+    @Binding var alertMessage: String
+
+    init(showingAlert: Binding<Bool>, alertMessage: Binding<String>, haveToNavigate: Binding<Bool>) {
+        _showingAlert = showingAlert
+        _alertMessage = alertMessage
+        _haveToNavigate = haveToNavigate
+    }
+
+    func readerSession(_ session: NFCNDEFReaderSession, didDetectNDEFs messages: [NFCNDEFMessage]) {
+        DispatchQueue.main.async {
+            self.haveToNavigate = true
+        }
+    }
+
+    func readerSession(_ session: NFCNDEFReaderSession, didInvalidateWithError error: Error) {
+        if let readerError = error as? NFCReaderError {
+
+            if readerError.code != .readerSessionInvalidationErrorFirstNDEFTagRead && readerError.code != .readerSessionInvalidationErrorUserCanceled {
+                DispatchQueue.main.async {
+                    self.alertMessage = error.localizedDescription
+                    self.showingAlert = true
+                }
+            }
+        }
+    }
+}
+
+
+#Preview {
+    NFCTagScanView()
+}


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
1. NFC 태그 기능을 구현하였고, 태그 스캔 시 발생할 수 있는 오류를 처리했습니다.
2. NFC 태그 스캔 뷰를 제작했습니다.(버튼과 아이콘 색은 저희 포인트 컬러로 변경하였습니다. )
3. 스캔 후 완료 작업은 컨텐츠뷰로 이동할 수 있도록 하였습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #8 
- 피그마 : 
- 관련 문서 : 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
-태그 스캔 시 조건을 두어 특정 태그만 스캔 가능하게 할까 고민중입니다. 태그의 페이로드나 record type 등을 읽어 원하는 태그를 판별하고 그 태그에 맞는 미팅룸 장소 뷰를 보여주는 것을 공부중입니다!!

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
![image](https://github.com/DeveloperAcademy-POSTECH/2024-NC2-M1-NFC/assets/160375101/9b8ce165-9759-4d7c-b3ce-120d560699b2)
![image](https://github.com/DeveloperAcademy-POSTECH/2024-NC2-M1-NFC/assets/160375101/395de33c-3481-4071-a443-12e24f5d7d27)
